### PR TITLE
Fix clubs being SQUASHED on iOS

### DIFF
--- a/src/components/Club.module.css
+++ b/src/components/Club.module.css
@@ -5,8 +5,8 @@
   justify-content: center;
   padding: 20px;
   border: none;
-  margin: 15px;
-  margin-top: 0;
+  margin: 15px 0;
+  width: 100%;
   box-sizing: border-box;
   border-radius: 10px;
   background-color: #ffa789;

--- a/src/components/ClubList.module.css
+++ b/src/components/ClubList.module.css
@@ -5,10 +5,8 @@
 }
 
 .list {
-  display: flex;
-  flex-direction: column;
   flex: 1 0 0;
-  padding-top: 15px;
+  padding: 0 15px;
   /* overflow: auto; */
   /* Momentum scrolling on iOS */
   -webkit-overflow-scrolling: touch;


### PR DESCRIPTION
Removes the catastrophe as witnessed in the following capture:
![Displeasure.](https://cdn.discordapp.com/attachments/685317074188238877/757354843592589442/image0.png)